### PR TITLE
Allow default stage, enable dotenv files

### DIFF
--- a/lambda_spike/.env.development
+++ b/lambda_spike/.env.development
@@ -1,1 +1,1 @@
-STAGE=dev
+NODE_ENV=dev

--- a/lambda_spike/.env.production
+++ b/lambda_spike/.env.production
@@ -1,1 +1,1 @@
-STAGE=prod
+NODE_ENV=prod

--- a/lambda_spike/package.json
+++ b/lambda_spike/package.json
@@ -11,10 +11,10 @@
     "serverless-domain-manager": "^5.1.0"
   },
   "scripts": {
-    "remove-dev": "export NODE_ENV=dev&& sls remove",
-    "remove-prod": "export NODE_ENV=prod&& sls remove",
-    "deploy-dev": "export NODE_ENV=dev&& sls deploy",
-    "deploy-prod": "export NODE_ENV=prod&& sls deploy",
+    "remove-dev": "sls remove --stage development",
+    "remove-prod": "sls remove --stage production",
+    "deploy-dev": "sls deploy --stage development",
+    "deploy-prod": "sls deploy --stage production",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/lambda_spike/serverless.yml
+++ b/lambda_spike/serverless.yml
@@ -12,6 +12,8 @@ custom:
     stage: ${self:provider.stage}
     createRoute53Record: true
 
+useDotenv: true
+
 service: youtube-my-spotify
 frameworkVersion: "2"
 

--- a/lambda_spike/serverless.yml
+++ b/lambda_spike/serverless.yml
@@ -2,15 +2,14 @@ plugins:
   - serverless-domain-manager
 
 custom:
-  stage: ${env:NODE_ENV}
-  dev:
+  development:
     domainName: dev.youtubemyspotify.co.uk
-  prod:
+  production:
     domainName: youtubemyspotify.co.uk
   customDomain:
     basePath: ""
-    domainName: ${self:custom.${self:custom.stage}.domainName}
-    stage: ${self:custom.stage}
+    domainName: ${self:custom.${self:provider.stage}.domainName}
+    stage: ${self:provider.stage}
     createRoute53Record: true
 
 service: youtube-my-spotify
@@ -20,7 +19,7 @@ provider:
   name: aws
   region: eu-west-2
   runtime: nodejs12.x
-  stage: ${self:custom.stage}
+  stage: ${opt:stage, 'development'}
   memorySize: 128
 
 functions:


### PR DESCRIPTION
This will default to `development` as stage, unless provided by `--stage`.

Also, it should fix the dotenv environment files.